### PR TITLE
chore: initialize pnpm monorepo with shared libs and hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.pnpm-store/
+.yarn/
+.DS_Store
+*.log

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,2 @@
+nodeLinker: node-modules
+npmPublishAccess: restricted

--- a/README.md
+++ b/README.md
@@ -1,1 +1,69 @@
-test data
+# yd-monorepo
+
+一个基于 pnpm 的前端 Monorepo，包含两个私有包：
+
+- `yd-libs`：通用工具库，提供日志和数值计算能力。
+- `yd-hooks`：React Hooks 集合，内部依赖 `yd-libs`。
+
+## 快速开始
+
+在首次开发之前请确保已经启用了 [Corepack](https://nodejs.org/api/corepack.html)，这样可以在同一台机器上同时管理 pnpm 与 yarn。
+
+```bash
+corepack enable
+```
+
+随后安装依赖：
+
+```bash
+pnpm install
+```
+
+> 项目使用 pnpm 进行依赖管理和包间协作，所有日常开发命令都通过 pnpm 触发。
+
+## 常用脚本
+
+- `pnpm build`：构建所有包，输出到各自的 `dist/` 目录。
+- `pnpm test`：在 JSDOM 环境下运行 Vitest 单元测试。
+- `pnpm lint`：调用 TypeScript 的类型检查。
+- `pnpm clean`：清理所有包的构建产物。
+
+## 包结构
+
+```
+packages/
+  yd-libs/
+    src/
+      index.ts            # 导出 Logger 与 calculateAverage
+  yd-hooks/
+    src/
+      index.ts            # 导出 useLogger 与 useAverage（依赖 yd-libs）
+```
+
+两个包都使用 [tsup](https://tsup.egoist.dev/) 进行打包，生成 CommonJS 和 ES Module 双格式并输出类型声明文件。
+
+## 使用 yarn 发版
+
+虽然仓库的日常开发依赖 pnpm，但发布流程使用 yarn 4。推荐的做法是：
+
+1. 确保当前环境可使用 yarn（默认 Corepack 会提供 `yarn 4.9.x`）。
+2. 在发版前执行 `pnpm build` 与必要的验证流程。
+3. 通过以下命令对所有需要发布的包执行 `npm publish`（默认访问权限为 `restricted`）：
+
+   ```bash
+   yarn workspaces foreach -pt npm publish --access restricted
+   ```
+
+   该命令会按依赖拓扑顺序逐个发布 workspace 包，确保 `yd-hooks` 在依赖的 `yd-libs` 之后发布。
+
+如需指定版本号或 tag，可在发布前使用 `pnpm version <new-version>` 更新对应包的版本信息。
+
+## 测试策略
+
+- `yd-libs` 使用 Vitest 对数值计算与 Logger 进行基础单元测试。
+- `yd-hooks` 借助 `@testing-library/react` 的 `renderHook` 验证与 `yd-libs` 的集成以及 Hooks 的行为。
+
+## 后续规划
+
+- 根据业务需求扩展 `yd-libs` 中的工具函数，并在 `yd-hooks` 中复用。
+- 在 CI 流程中加入发布前校验（lint/build/test），保证使用 yarn 发版时的稳定性。

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "yd-monorepo",
+  "version": "0.1.0",
+  "private": true,
+  "packageManager": "pnpm@8.15.4",
+  "scripts": {
+    "build": "pnpm -r run build",
+    "clean": "pnpm -r run clean",
+    "lint": "pnpm -r run lint",
+    "test": "pnpm -r run test",
+    "release": "yarn workspaces foreach -pt npm publish --access restricted"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.1.2",
+    "@types/react": "^18.2.25",
+    "@types/react-dom": "^18.2.11",
+    "jsdom": "^24.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "rimraf": "^5.0.5",
+    "tsup": "^7.2.0",
+    "typescript": "^5.4.5",
+    "vitest": "^0.34.6"
+  }
+}

--- a/packages/yd-hooks/package.json
+++ b/packages/yd-hooks/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "yd-hooks",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "clean": "rimraf dist",
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "yd-libs": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/packages/yd-hooks/src/index.test.tsx
+++ b/packages/yd-hooks/src/index.test.tsx
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Logger } from 'yd-libs';
+import { useAverage, useLogger } from './index';
+
+describe('useLogger', () => {
+  it('creates memoized logger instances', () => {
+    const { result, rerender } = renderHook((props: { prefix?: string }) =>
+      useLogger({ prefix: props.prefix, level: 'info' }),
+      { initialProps: { prefix: 'first' } },
+    );
+
+    const firstInstance = result.current;
+    rerender({ prefix: 'first' });
+    expect(result.current).toBe(firstInstance);
+
+    rerender({ prefix: 'second' });
+    expect(result.current).not.toBe(firstInstance);
+  });
+});
+
+describe('useAverage', () => {
+  it('calculates the average using yd-libs', () => {
+    const { result } = renderHook(({ values }: { values: number[] }) => useAverage(values), {
+      initialProps: { values: [1, 2, 3, 4] },
+    });
+
+    expect(result.current).toBe(2.5);
+  });
+
+  it('logs the calculated average when a logger is provided', () => {
+    const logger = new Logger({ level: 'debug' });
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
+
+    const { rerender } = renderHook(
+      ({ values }: { values: number[] }) => useAverage(values, { logger, logLevel: 'info' }),
+      {
+        initialProps: { values: [1, 2] },
+      },
+    );
+
+    expect(infoSpy).toHaveBeenCalledWith('Average: 1.5');
+
+    rerender({ values: [4, 5] });
+    expect(infoSpy).toHaveBeenCalledWith('Average: 4.5');
+  });
+});

--- a/packages/yd-hooks/src/index.ts
+++ b/packages/yd-hooks/src/index.ts
@@ -1,0 +1,64 @@
+import { useEffect, useMemo } from 'react';
+import type { AverageOptions, LogLevel, LoggerOptions } from 'yd-libs';
+import { Logger, calculateAverage } from 'yd-libs';
+
+export interface UseLoggerOptions extends LoggerOptions {
+  /**
+   * Optional dependencies that should recreate the logger instance when they change.
+   */
+  dependencies?: ReadonlyArray<unknown>;
+}
+
+export function useLogger(options: UseLoggerOptions = {}): Logger {
+  const { dependencies = [], ...loggerOptions } = options;
+  return useMemo(
+    () => new Logger(loggerOptions),
+    [loggerOptions.level, loggerOptions.prefix, ...dependencies],
+  );
+}
+
+export interface UseAverageOptions extends AverageOptions {
+  /**
+   * Whether to log the calculated average through the provided logger instance.
+   */
+  logger?: Logger;
+  /**
+   * Optional level to log the calculated average.
+   */
+  logLevel?: LogLevel;
+}
+
+function logWithLevel(logger: Logger, level: LogLevel, message: string): void {
+  switch (level) {
+    case 'debug':
+      logger.debug(message);
+      break;
+    case 'info':
+      logger.info(message);
+      break;
+    case 'warn':
+      logger.warn(message);
+      break;
+    case 'error':
+      logger.error(message);
+      break;
+    default:
+      logger.info(message);
+  }
+}
+
+export function useAverage(values: number[], options: UseAverageOptions = {}): number {
+  const { logger, logLevel = 'info', ...averageOptions } = options;
+
+  const average = useMemo(() => {
+    return calculateAverage(values, averageOptions);
+  }, [values, averageOptions.precision]);
+
+  useEffect(() => {
+    if (logger) {
+      logWithLevel(logger, logLevel, `Average: ${average}`);
+    }
+  }, [logger, logLevel, average]);
+
+  return average;
+}

--- a/packages/yd-hooks/tsconfig.json
+++ b/packages/yd-hooks/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist"
+  }
+}

--- a/packages/yd-libs/package.json
+++ b/packages/yd-libs/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "yd-libs",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "clean": "rimraf dist",
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
+  }
+}

--- a/packages/yd-libs/src/index.test.ts
+++ b/packages/yd-libs/src/index.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { Logger, calculateAverage } from './index';
+
+describe('calculateAverage', () => {
+  it('computes the average with default precision', () => {
+    expect(calculateAverage([1, 2, 3])).toBe(2);
+  });
+
+  it('respects the provided precision', () => {
+    expect(calculateAverage([1, 2], { precision: 1 })).toBe(1.5);
+  });
+
+  it('throws when called without values', () => {
+    expect(() => calculateAverage([])).toThrow(/at least one value/);
+  });
+});
+
+describe('Logger', () => {
+  it('does not throw when logging at different levels', () => {
+    const logger = new Logger({ level: 'debug', prefix: 'test' });
+    expect(() => {
+      logger.debug('debug message');
+      logger.info('info message');
+      logger.warn('warn message');
+      logger.error('error message');
+    }).not.toThrow();
+  });
+});

--- a/packages/yd-libs/src/index.ts
+++ b/packages/yd-libs/src/index.ts
@@ -1,0 +1,72 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LoggerOptions {
+  level?: LogLevel;
+  prefix?: string;
+}
+
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+export class Logger {
+  private readonly level: LogLevel;
+  private readonly prefix?: string;
+
+  constructor(options: LoggerOptions = {}) {
+    this.level = options.level ?? 'info';
+    this.prefix = options.prefix;
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    return LEVEL_PRIORITY[level] >= LEVEL_PRIORITY[this.level];
+  }
+
+  private formatMessage(message: unknown): string {
+    const base = typeof message === 'string' ? message : JSON.stringify(message);
+    return this.prefix ? `[${this.prefix}] ${base}` : base;
+  }
+
+  debug(message: unknown): void {
+    if (this.shouldLog('debug')) {
+      console.debug(this.formatMessage(message));
+    }
+  }
+
+  info(message: unknown): void {
+    if (this.shouldLog('info')) {
+      console.info(this.formatMessage(message));
+    }
+  }
+
+  warn(message: unknown): void {
+    if (this.shouldLog('warn')) {
+      console.warn(this.formatMessage(message));
+    }
+  }
+
+  error(message: unknown): void {
+    if (this.shouldLog('error')) {
+      console.error(this.formatMessage(message));
+    }
+  }
+}
+
+export interface AverageOptions {
+  precision?: number;
+}
+
+export function calculateAverage(values: number[], options: AverageOptions = {}): number {
+  if (values.length === 0) {
+    throw new Error('calculateAverage requires at least one value');
+  }
+
+  const { precision = 2 } = options;
+  const sum = values.reduce((acc, value) => acc + value, 0);
+  const average = sum / values.length;
+  const factor = 10 ** precision;
+  return Math.round(average * factor) / factor;
+}

--- a/packages/yd-libs/tsconfig.json
+++ b/packages/yd-libs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ESNext",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: [],
+  },
+});


### PR DESCRIPTION
## Summary
- initialize a pnpm-managed workspace with Yarn-based release workflow configuration
- add private yd-libs package providing logging utilities and numeric helpers with tests
- add private yd-hooks package consuming yd-libs to expose React hooks and associated tests

## Testing
- pnpm install *(fails: registry access blocked in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce57250120832295d4edcee0581c50